### PR TITLE
Directly obtain numpy image from ImageDataModel

### DIFF
--- a/dicom2hdf/data_model.py
+++ b/dicom2hdf/data_model.py
@@ -87,7 +87,7 @@ class ImageAndSegmentationDataModel:
     """
     image: ImageDataModel
     segmentations: Sequence[SegmentationDataModel] = None
-    
+
 
 @dataclass
 class PatientDataModel:

--- a/dicom2hdf/data_model.py
+++ b/dicom2hdf/data_model.py
@@ -68,7 +68,8 @@ class ImageDataModel:
     series_key: str = None
     transforms_key: str = None
         
-    def get_numpy_array(self):
+    @property
+    def numpy_array(self):
         return sitk.GetArrayFromImage(self.simple_itk_image)
 
 

--- a/dicom2hdf/data_model.py
+++ b/dicom2hdf/data_model.py
@@ -88,8 +88,6 @@ class ImageAndSegmentationDataModel:
     image: ImageDataModel
     segmentations: Sequence[SegmentationDataModel] = None
     
-    
-
 
 @dataclass
 class PatientDataModel:

--- a/dicom2hdf/data_model.py
+++ b/dicom2hdf/data_model.py
@@ -54,7 +54,7 @@ class ImageDataModel:
     dicom_header : FileDataset
         Dicom header dataset.
     simple_itk_image : Image
-        Segmentation as a SimpleITK image.
+        Dicom data volume as a SimpleITK image.
     paths_to_dicoms : Sequence[str]
         A list of the paths to each dicom contained in the series.
     series_key : str
@@ -67,6 +67,9 @@ class ImageDataModel:
     simple_itk_image: sitk.Image
     series_key: str = None
     transforms_key: str = None
+        
+    def get_numpy_array(self):
+        return sitk.GetArrayFromImage(self.simple_itk_image)
 
 
 @dataclass
@@ -84,6 +87,8 @@ class ImageAndSegmentationDataModel:
     """
     image: ImageDataModel
     segmentations: Sequence[SegmentationDataModel] = None
+    
+    
 
 
 @dataclass


### PR DESCRIPTION
This PR would add a helper method to ImageDataModel which allows to directly get a numpy array, removing the need for users to potentially work with sitk when not necessary.

There is also a minor documentation change for simple_itk_image as the sitk image is not always a segmentation, but rather a data volume from the dicom file(s).

As a side note, although this *could* change the 2nd example on the README it is most likely a better idea to keep the example as is to illustrate the presence of an sitk image

-------------------------------
Potential alternative; use it as a property with
```py
@property
def numpy_array(self):
    return sitk.GetArrayFromImage(self.simple_itk_image)
```

which can then be called with (assuming example 2)
```py
patient_image_data.image.numpy_array
```