### PR TITLE
implemented shallow_hierarchy option for create()

### DIFF
--- a/delia/readers/patient_data/factories/base_patient_data_factory.py
+++ b/delia/readers/patient_data/factories/base_patient_data_factory.py
@@ -77,6 +77,18 @@ class BasePatientDataFactory(ABC):
 
         return str(patient_id)
 
+    @property
+    def patient_path(self) -> str:
+        """
+        Patient data path.
+
+        Returns
+        -------
+        patient_path : str
+            Patient folder path.
+        """
+        return str(self._path_to_patient_folder)
+
     @staticmethod
     def get_segmentation_reference_uid(segmentation_header: pydicom.dataset.FileDataset) -> pydicom.DataElement:
         """

--- a/delia/readers/patient_data/factories/patient_data_factories.py
+++ b/delia/readers/patient_data/factories/patient_data_factories.py
@@ -97,6 +97,7 @@ class DefaultPatientDataFactory(BasePatientDataFactory):
 
         patient_data = PatientDataModel(
             patient_id=self.patient_id,
+            patient_path=self.patient_path,
             data=data
         )
         return patient_data
@@ -198,6 +199,7 @@ class SpecificTagPatientDataFactory(BasePatientDataFactory):
 
         patient_data = PatientDataModel(
             patient_id=self.patient_id,
+            patient_path=self.patient_path,
             data=data
         )
         return patient_data

--- a/delia/readers/patient_data/patient_data_reader.py
+++ b/delia/readers/patient_data/patient_data_reader.py
@@ -70,6 +70,7 @@ class PatientDataReader(DicomReader):
         self._tag_values = tag_values
         self._erase_unused_dicom_files = erase_unused_dicom_files
         self._organs = organs
+        self._path_to_patient_folder = path_to_patient_folder
 
         self.failed_images = []
         if tag_values is not None:
@@ -86,6 +87,18 @@ class PatientDataReader(DicomReader):
             Patient id.
         """
         return str(self._images_dicom_headers[0].PatientID)
+
+    @property
+    def patient_path(self) -> str:
+        """
+        Patient Path.
+
+        Returns
+        -------
+        patient_path : str
+            Patient folder path
+        """
+        return str(self._path_to_patient_folder)
 
     @property
     def paths_to_segmentations(self) -> List[str]:

--- a/delia/utils/data_model.py
+++ b/delia/utils/data_model.py
@@ -110,6 +110,7 @@ class PatientDataModel:
 
         PatientDataModel = (
             "patient_id": str,
+            "patient_path": str,
             "data": [
                 ImageAndSegmentationDataModel,
                 ImageAndSegmentationDataModel
@@ -119,5 +120,6 @@ class PatientDataModel:
         )
     """
     patient_id: str
+    patient_path: str
     data: List[ImageAndSegmentationDataModel]
     transforms_history: Optional[TransformsHistory] = None


### PR DESCRIPTION
This PR implements a `shallow_hierarchy` option to the database `create()` function which allows to be set to create a rather shallow data hierarchy which is also based on the actual subdir/path name of the directory structure to convert. Thus, by using this `shallow_hierarchy` option one can more easily convert dicom data to hdf5 data patient-wise. E.g., have an actual `image` and `label` sub directory with dicom data and then see it converted into a shallow hierarchy with

`/image`
`/label`

rather than a deep hierarchy as the create() function usually creates.