### PR TITLE
implemented transpose option to be able to disable the transpose

### DIFF
--- a/delia/databases/patients_database.py
+++ b/delia/databases/patients_database.py
@@ -227,7 +227,8 @@ class PatientsDatabase:
             tags_to_use_as_attributes: Optional[List[Tuple[int, int]]] = None,
             add_sitk_image_metadata_as_attributes: bool = True,
             organs_to_keep: Optional[Union[str, List[str]]] = None,
-            overwrite_database: bool = False
+            overwrite_database: bool = False,
+            transpose: bool = True
     ) -> List[PatientWhoFailed]:
         """
         Create an hdf5 file database from multiple patients dicom files and their segmentation. The goal is to create
@@ -247,6 +248,8 @@ class PatientsDatabase:
             Organ segmentations to keep in the database. By default, all organs are kept.
         overwrite_database : bool, default = False.
             Overwrite existing database.
+        transpose : bool, default = True.
+            Transpose the image array before using it.
 
         Returns
         -------
@@ -283,11 +286,14 @@ class PatientsDatabase:
                         data=json.dumps(patient_image_data.image.dicom_header.to_json_dict())
                     )
 
-                    image_array = sitk.GetArrayFromImage(patient_image_data.image.simple_itk_image)
+                    if transpose is True:
+                      image_array = self._transpose(sitk.GetArrayFromImage(patient_image_data.image.simple_itk_image))
+                    else:
+                      image_array = sitk.GetArrayFromImage(patient_image_data.image.simple_itk_image)
 
                     series_group.create_dataset(
                         name=self.IMAGE,
-                        data=self._transpose(image_array)
+                        data=image_array
                     )
 
                     if patient_image_data.segmentations:
@@ -296,12 +302,15 @@ class PatientsDatabase:
                             segmentation_group.attrs.create(name=self.MODALITY, data=segmentation.modality)
 
                             for organ, simple_itk_label_map in segmentation.simple_itk_label_maps.items():
-                                numpy_array_label_map = sitk.GetArrayFromImage(simple_itk_label_map)
+                                if transpose is True:
+                                    numpy_array_label_map = self._transpose(sitk.GetArrayFromImage(simple_itk_label_map))
+                                else:
+                                    numpy_array_label_map = sitk.GetArrayFromImage(simple_itk_label_map)
 
                                 if organs_to_keep is None or organ in organs_to_keep:
                                     segmentation_group.create_dataset(
                                         name=organ,
-                                        data=self._transpose(numpy_array_label_map),
+                                        data=numpy_array_label_map,
                                         dtype=np.int8
                                     )
 


### PR DESCRIPTION
This PR adds an addition `transpose` option to the database `create()` function which per default is set to `True` and will perform the standard `self._transpose()` operation. However, if set to `False` this data/image transpose before storing the image array into the hdf5 dataset can be disabled – which under certain circumstances is necessary and required.