### PR TITLE
Fix extra transpose being applied to images

### DIFF
--- a/delia/databases/patients_database.py
+++ b/delia/databases/patients_database.py
@@ -307,7 +307,7 @@ class PatientsDatabase:
 
                     data_set = series_group.create_dataset(
                         name=image_name,
-                        data=self._transpose(image_array)
+                        data=image_array
                     )
 
                     if shallow_hierarchy is True:


### PR DESCRIPTION
This pull request removes an extra call to the `_transpose()` method being performed after the optional transpose block on image arrays but not on segmentation mask arrays in the `create()` method of `PatientsDatabase`.